### PR TITLE
Configure Xilinx xtclsh location via environment variable (optional).

### DIFF
--- a/src/Development/KansasLava/Shake/Xilinx.hs
+++ b/src/Development/KansasLava/Shake/Xilinx.hs
@@ -9,6 +9,7 @@ import           Development.Shake          hiding ((~>))
 import           Development.Shake.FilePath
 
 import qualified Data.Text                  as T
+import           System.Environment         (lookupEnv)
 import           Text.Mustache
 import           Text.Mustache.Types
 
@@ -33,7 +34,9 @@ xilinxRules XilinxConfig{..} outDir projName srcs ipcores = do
     outDir </> "*.tcl" %> do
         mustache projCtxt
   where
-    xilinx tool args = cmd (Cwd outDir) (xilinxRoot </> tool) args
+    xilinx tool args = liftIO $ do
+      xilinxRootEnv <- lookupEnv "KANSAS_LAVA_XILINX_ROOT" -- optional xtclsh dir
+      cmd (Cwd outDir) ((maybe xilinxRoot id xilinxRootEnv) </> tool) args
 
     projCtxt = object $ [
         "project" ~=  projName,


### PR DESCRIPTION
Hi Gergo, I made a small addition to enable the site-local configuration of the xtclsh script via an environment variable. If not set, the existing behavior is unchanged (i.e. should not break your setup). I use this to point at a local `xtclsh` wrapper script that then ssh's and scp's to my remote machine that has the ISE setup.